### PR TITLE
Updated debug to 2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "2.2.0",
+    "debug": "2.6.9",
     "ioredis": "^1.7.3",
     "msgpack-js": "0.3.0",
     "socket.io-adapter": "^0.4.0",


### PR DESCRIPTION
debug@2.2.0 has a dependency ms@0.7.1 that wont avoid ReDos, it is fixed in ms@2.0.0
https://github.com/zeit/ms/commit/caae2988ba2a37765d055c4eee63d383320ee662